### PR TITLE
Remove ID from memblock_s. This variable is used only to check if the…

### DIFF
--- a/doomdef.h
+++ b/doomdef.h
@@ -621,7 +621,6 @@ typedef struct memblock_s
 	int		size;           /* including the header and possibly tiny fragments */
 	void    **user;         /* NULL if a free block */
 	short   tag;            /* purgelevel */
-	short   id;             /* should be ZONEID */
 #ifndef MARS
 	int		lockframe;		/* don't purge on the same frame */
 #endif

--- a/r_phase5.c
+++ b/r_phase5.c
@@ -83,7 +83,6 @@ backtostart:
       //
       // free the rover block (adding the size to base)
       //
-      rover->id   = 0;
       rover->user = NULL; // mark as free
 
       if(base != rover)
@@ -118,7 +117,6 @@ backtostart:
 
    base->user = user; // mark as an in use block
    base->lockframe = framecount; // mark as in use for this frame
-   base->id = ZONEID;
    base->tag = PU_CACHE;
 
    refzone->rover = base->next; // next allocation will start looking here

--- a/z_zone.c
+++ b/z_zone.c
@@ -41,7 +41,6 @@ memzone_t *Z_InitZone (byte *base, int size)
 	zone->blocklist.size = size - 8;
 	zone->blocklist.user = NULL;
 	zone->blocklist.tag = 0;
-	zone->blocklist.id = ZONEID;
 	zone->blocklist.next = NULL;
 	zone->blocklist.prev = NULL;
 #ifndef MARS
@@ -88,14 +87,11 @@ void Z_Free2 (memzone_t *mainzone, void *ptr)
 	memblock_t	*block, *adj;
 	
 	block = (memblock_t *) ( (byte *)ptr - sizeof(memblock_t));
-	if (block->id != ZONEID)
-		I_Error ("Z_Free: freed a pointer without ZONEID");
 		
 	if (block->user > (void **)0x100)	/* smaller values are not pointers */
 		*block->user = 0;		/* clear the user's mark */
 	block->user = NULL;	/* mark as free */
 	block->tag = 0;
-	block->id = 0;
 
 	// merge with adjacent blocks
 	adj = block->prev;
@@ -208,7 +204,6 @@ backtostart:
 		base->user = (void *)2;		/* mark as in use, but unowned	 */
 	}
 	base->tag = tag;
-	base->id = ZONEID;
 #ifndef MARS
 	base->lockframe = -1;
 #endif	
@@ -287,8 +282,6 @@ void Z_ChangeTag (void *ptr, int tag)
 	memblock_t	*block;
 	
 	block = (memblock_t *) ( (byte *)ptr - sizeof(memblock_t));
-	if (block->id != ZONEID)
-		I_Error ("Z_ChangeTag: freed a pointer without ZONEID");
 	if (tag >= PU_PURGELEVEL && (int)block->user < 0x100)
 		I_Error ("Z_ChangeTag: an owner is required for purgable blocks");
 	block->tag = tag;


### PR DESCRIPTION
… memory in the zone is corrupted. Slighty faster and uses less RAM. I've tested this extensively on FastDoom and 486Quake without any problems.