### PR TITLE
Chasecam during demo playback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ OBJS = \
 	d_main.o \
 	g_game.o \
 	info.o \
+	p_camera.o \
 	p_ceilng.o \
 	p_doors.o \
 	p_enemy.o \

--- a/doomdef.h
+++ b/doomdef.h
@@ -18,6 +18,9 @@
 /* will not be compiled */
 #define	RANGECHECK
 
+#define USECAMERA
+#define USECAMERAFORDEMOS
+
 /* if SIMULATOR is defined, compile in extra code for things like console */
 /* debugging aids */
 #ifndef JAGUAR

--- a/p_camera.c
+++ b/p_camera.c
@@ -1,0 +1,442 @@
+#include "p_camera.h"
+
+#ifdef USECAMERA
+camera_t camera, camera2;
+//#define NOCLIPCAMERA
+
+static boolean PIT_CameraCheckLine(line_t *ld, pmovework_t *mw)
+{
+   fixed_t   opentop, openbottom, lowfloor;
+   sector_t *front, *back;
+
+   // The moving thing's destination positoin will cross the given line.
+   // If this should not be allowed, return false.
+   if(ld->sidenum[1] == -1)
+      return false; // one-sided line
+
+   if(ld->flags & ML_BLOCKING)
+      return false; // explicitly blocking everything
+
+   front = LD_FRONTSECTOR(ld);
+   back  = LD_BACKSECTOR(ld);
+
+   if(front->ceilingheight == front->floorheight ||
+      back->ceilingheight == back->floorheight)
+   {
+      mw->blockline = ld;
+      return false; // probably a closed door
+   }
+
+   if(front->ceilingheight < back->ceilingheight)
+      opentop = front->ceilingheight;
+   else
+      opentop = back->ceilingheight;
+
+   if(front->floorheight > back->floorheight)
+   {
+      openbottom = front->floorheight;
+      lowfloor   = back->floorheight;
+   }
+   else
+   {
+      openbottom = back->floorheight;
+      lowfloor   = front->floorheight;
+   }
+
+   // adjust floor/ceiling heights
+   if(opentop < mw->tmceilingz)
+      mw->tmceilingz = opentop;
+   if(openbottom >mw->tmfloorz)
+      mw->tmfloorz = openbottom;
+   if(lowfloor < mw->tmdropoffz)
+      mw->tmdropoffz = lowfloor;
+
+   return true;
+}
+
+static boolean PM_CameraCrossCheck(line_t *ld, pmovework_t *mw)
+{
+   if(PM_BoxCrossLine(ld, mw))
+   {
+      if(!PIT_CameraCheckLine(ld, mw))
+         return false;
+   }
+   return true;
+}
+
+static boolean PM_CameraCheckPosition(pmovework_t *mw)
+{
+   int xl, xh, yl, yh, bx, by;
+   mobj_t *tmthing = mw->tmthing;
+   VINT *lvalidcount;
+
+   mw->tmflags = tmthing->flags;
+
+   mw->tmbbox[BOXTOP   ] = mw->tmy + tmthing->radius;
+   mw->tmbbox[BOXBOTTOM] = mw->tmy - tmthing->radius;
+   mw->tmbbox[BOXRIGHT ] = mw->tmx + tmthing->radius;
+   mw->tmbbox[BOXLEFT  ] = mw->tmx - tmthing->radius;
+
+   mw->newsubsec = R_PointInSubsector(mw->tmx, mw->tmy);
+
+   // the base floor/ceiling is from the subsector that contains the point.
+   // Any contacted lines the step closer together will adjust them.
+   mw->tmfloorz   = mw->tmdropoffz = mw->newsubsec->sector->floorheight;
+   mw->tmceilingz = mw->newsubsec->sector->ceilingheight;
+
+   I_GetThreadLocalVar(DOOMTLS_VALIDCOUNT, lvalidcount);
+   *lvalidcount = *lvalidcount + 1;
+   if (*lvalidcount == 0)
+      *lvalidcount = 1;
+
+   mw->blockline = NULL;
+   mw->numspechit = 0;
+
+   if(mw->tmflags & MF_NOCLIP) // thing has no clipping?
+      return true;
+
+   // check lines
+   xl = mw->tmbbox[BOXLEFT  ] - bmaporgx;
+   xh = mw->tmbbox[BOXRIGHT ] - bmaporgx;
+   yl = mw->tmbbox[BOXBOTTOM] - bmaporgy;
+   yh = mw->tmbbox[BOXTOP   ] - bmaporgy;
+
+   if(xl < 0)
+      xl = 0;
+   if(yl < 0)
+      yl = 0;
+	if(yh < 0 || xh < 0)
+		return true;
+
+   xl = (unsigned)xl >> MAPBLOCKSHIFT;
+   xh = (unsigned)xh >> MAPBLOCKSHIFT;
+   yl = (unsigned)yl >> MAPBLOCKSHIFT;
+   yh = (unsigned)yh >> MAPBLOCKSHIFT;
+
+   if(xh >= bmapwidth)
+      xh = bmapwidth - 1;
+   if(yh >= bmapheight)
+      yh = bmapheight - 1;
+
+   for(bx = xl; bx <= xh; bx++)
+   {
+      for(by = yl; by <= yh; by++)
+      {
+         if(!P_BlockLinesIterator(bx, by, (blocklinesiter_t)PM_CameraCrossCheck, mw))
+            return false;
+      }
+   }
+
+   return true;
+}
+
+static boolean P_CameraTryMove2(ptrymove_t *tm, boolean checkposonly)
+{
+   pmovework_t mw;
+   boolean trymove2; // result from P_CameraTryMove2
+   mobj_t *tmthing = tm->tmthing;
+
+   mw.tmx = tm->tmx;
+   mw.tmy = tm->tmy;
+   mw.tmthing = tm->tmthing;
+   mw.spechit = &tm->spechit[0];
+
+   trymove2 = PM_CameraCheckPosition(&mw);
+
+   tm->floatok = false;
+   tm->blockline = mw.blockline;
+   tm->tmfloorz = mw.tmfloorz;
+   tm->tmceilingz = mw.tmceilingz;
+   tm->tmdropoffz = mw.tmdropoffz;
+
+   if(checkposonly)
+      return trymove2;
+
+   if(!trymove2)
+      return false;
+
+   if(!(tmthing->flags & MF_NOCLIP))
+   {
+      if(mw.tmceilingz - mw.tmfloorz < tmthing->height)
+         return false; // doesn't fit
+      tm->floatok = true;
+      if(mw.tmceilingz - tmthing->z < tmthing->height)
+         return false; // mobj must lower itself to fit
+      if(mw.tmfloorz - tmthing->z > 24*FRACUNIT)
+         return false; // too big a step up
+      if(!(tmthing->flags & (MF_DROPOFF|MF_FLOAT)) && mw.tmfloorz - mw.tmdropoffz > 24*FRACUNIT)
+         return false; // don't stand over a dropoff
+   }
+
+   // the move is ok, so link the thing into its new position.
+   tmthing->floorz   = mw.tmfloorz;
+   tmthing->ceilingz = mw.tmceilingz;
+   tmthing->x = mw.tmx;
+   tmthing->y = mw.tmy;
+
+   return true;
+}
+
+static boolean P_CameraTryMove (ptrymove_t *tm, mobj_t *thing, fixed_t x, fixed_t y)
+{
+	tm->tmthing = thing;
+	tm->tmx = x;
+	tm->tmy = y;
+	return P_CameraTryMove2 (tm, false);
+}
+
+//
+// Try to slide the player against walls by finding the closest move available.
+//
+static void P_CameraSlideMove(pslidemove_t *sm)
+{
+   int i;
+   fixed_t dx, dy, rx, ry;
+   fixed_t frac, slide;
+   pslidework_t sw;
+   mobj_t *slidething = sm->slidething;
+
+   dx = slidething->momx;
+   dy = slidething->momy;
+   sw.slidex = slidething->x;
+   sw.slidey = slidething->y;
+   sw.slidething = slidething;
+   sw.numspechit = 0;
+   sw.spechit = &sm->spechit[0];
+
+   // perform a maximum of three bumps
+   for(i = 0; i < 3; i++)
+   {
+      frac = P_CompletableFrac(&sw, dx, dy);
+      if(frac != FRACUNIT)
+         frac -= 0x1000;
+      if(frac < 0)
+         frac = 0;
+
+      rx = FixedMul(frac, dx);
+      ry = FixedMul(frac, dy);
+
+      sw.slidex += rx;
+      sw.slidey += ry;
+
+      // made it the entire way
+      if(frac == FRACUNIT)
+      {
+         slidething->momx = dx;
+         slidething->momy = dy;
+//         SL_CheckSpecialLines(&sw); // Camera doesn't trip lines
+         sm->slidex = sw.slidex;
+         sm->slidey = sw.slidey;
+         return;
+      }
+
+      // project the remaining move along the line that blocked movement
+      dx -= rx;
+      dy -= ry;
+      dx = FixedMul(dx, sw.blocknvx);
+      dy = FixedMul(dy, sw.blocknvy);
+      slide = dx + dy;
+
+      dx = FixedMul(slide, sw.blocknvx);
+      dy = FixedMul(slide, sw.blocknvy);
+   }
+
+   // some hideous situation has happened that won't let the camera slide
+   sm->slidex = slidething->x;
+   sm->slidey = slidething->y;
+   sm->slidething->momx = slidething->momy = 0;
+}
+
+static void P_ResetCamera(player_t *player, camera_t *thiscam)
+{
+	thiscam->x = player->mo->x;
+	thiscam->y = player->mo->y;
+	thiscam->z = player->mo->z + VIEWHEIGHT;
+}
+
+// Process the mobj-ish required functions of the camera
+static void P_CameraThinker(player_t *player, camera_t *thiscam)
+{
+#ifdef NOCLIPCAMERA
+   	thiscam->x += thiscam->momx;
+   	thiscam->y += thiscam->momy;
+   	thiscam->z += thiscam->momz;
+   	return;
+#else
+	// P_CameraXYMovement()
+	if (thiscam->momx || thiscam->momy)
+   	{
+		fixed_t momx, momy;
+      	pslidemove_t sm;
+      	ptrymove_t tm;
+
+		momx = vblsinframe*(thiscam->momx>>2);
+		momy = vblsinframe*(thiscam->momy>>2);
+
+		mobj_t mo; // Our temporary dummy to pretend we are a mobj
+		mo.flags = MF_SOLID|MF_FLOAT;
+		mo.x = thiscam->x;
+		mo.y = thiscam->y;
+		mo.z = thiscam->z;
+		mo.floorz = thiscam->floorz;
+		mo.ceilingz = thiscam->ceilingz;
+		mo.momx = thiscam->momx;
+		mo.momy = thiscam->momy;
+		mo.momz = thiscam->momz;
+		mo.radius = CAM_RADIUS;
+		mo.height = CAM_HEIGHT;
+		sm.slidething = &mo;
+
+		P_CameraSlideMove(&sm);
+
+		if (sm.slidex == mo.x && sm.slidey == mo.y)
+			goto camstairstep;
+
+		if (P_CameraTryMove(&tm, &mo, sm.slidex, sm.slidey))
+			goto camwrapup;
+
+camstairstep:
+		// something fucked up in slidemove, so stairstep
+		if (P_CameraTryMove(&tm, &mo, mo.x, mo.y + momy))
+		{
+			mo.momx = 0;
+			mo.momy = momy;
+			goto camwrapup;
+		}
+
+		if (P_CameraTryMove(&tm, &mo, mo.x + momx, mo.y))
+		{
+			mo.momx = momx;
+			mo.momy = 0;
+			goto camwrapup;
+		}
+
+		mo.momx = mo.momy = 0;
+
+camwrapup:
+		thiscam->x = mo.x;
+		thiscam->y = mo.y;
+		thiscam->z = mo.z;
+		thiscam->floorz = mo.floorz;
+		thiscam->ceilingz = mo.ceilingz;
+		thiscam->momx = mo.momx;
+		thiscam->momy = mo.momy;
+		thiscam->momz = mo.momz;
+   }
+
+	// P_CameraZMovement()
+	if (thiscam->momz)
+	{
+   		thiscam->z += thiscam->momz;
+
+		// clip movement
+		if (thiscam->z <= thiscam->floorz) // hit the floor
+		{
+			thiscam->z = thiscam->floorz;
+			if (thiscam->z > player->viewz + CAM_HEIGHT + (16 << FRACBITS))
+			{
+				// Camera got stuck, so reset it
+				P_ResetCamera(player, thiscam);
+			}
+		}
+
+		if (thiscam->z + CAM_HEIGHT > thiscam->ceilingz)
+		{
+			if (thiscam->momz > 0)
+			{
+				// hit the ceiling
+				thiscam->momz = 0;
+			}
+
+			thiscam->z = thiscam->ceilingz - CAM_HEIGHT;
+
+			if (thiscam->z + CAM_HEIGHT < player->mo->z - player->mo->height)
+			{
+				// Camera got stuck, so reset it
+				P_ResetCamera(player, thiscam);
+			}
+		}
+	}
+
+   	if (thiscam->ceilingz - thiscam->z < CAM_HEIGHT && thiscam->ceilingz >= thiscam->z)
+	{
+		thiscam->ceilingz = thiscam->z + CAM_HEIGHT;
+		thiscam->floorz = thiscam->z;
+	}
+#endif
+}
+
+void P_MoveChaseCamera(player_t *player, camera_t *thiscam)
+{
+	angle_t angle = 0;
+	angle_t focusangle = 0;
+	fixed_t x, y, z, viewpointx, viewpointy, camspeed, camdist, camheight, pviewheight;
+	fixed_t dist;
+	mobj_t *mo;
+	subsector_t *newsubsec;
+
+	mo = player->mo;
+//	const fixed_t radius = CAM_RADIUS;
+	const fixed_t height = CAM_HEIGHT;
+
+	angle = focusangle = mo->angle;
+
+	P_CameraThinker(player, thiscam);
+
+	camspeed = FRACUNIT / 4;
+	camdist = CAM_DIST;
+	camheight = 20 << FRACBITS;
+
+	if (P_AproxDistance(thiscam->x - mo->x, thiscam->y - mo->y) > camdist * 2)
+	{
+		// Camera got stuck, so reset it
+		P_ResetCamera(player, thiscam);
+	}
+
+	dist = camdist;
+
+	// sets ideal cam pos
+	if (player->health <= 0)
+		dist >>= 1;
+
+	x = mo->x - FixedMul(finecosine((angle>>ANGLETOFINESHIFT) & FINEMASK), dist);
+	y = mo->y - FixedMul(finesine((angle>>ANGLETOFINESHIFT) & FINEMASK), dist);
+
+	pviewheight = VIEWHEIGHT;
+
+	z = mo->z + pviewheight + camheight;
+
+	// move camera down to move under lower ceilings
+	newsubsec = R_PointInSubsector(((mo->x>>FRACBITS) + (thiscam->x>>FRACBITS))<<(FRACBITS-1), ((mo->y>>FRACBITS) + (thiscam->y>>FRACBITS))<<(FRACBITS-1));
+
+	{
+		const fixed_t myfloorz = newsubsec->sector->floorheight;
+		const fixed_t myceilingz = newsubsec->sector->ceilingheight;
+
+		// camera fit?
+		if (myceilingz != myfloorz
+			&& myceilingz - height < z)
+		{
+			// no fit
+			z = myceilingz - height-(11<<FRACBITS);
+		}
+	}
+
+	if (thiscam->z < thiscam->floorz)
+		thiscam->z = thiscam->floorz;
+
+	// point viewed by the camera
+	// this point is just 64 unit forward the player
+	dist = 64 << FRACBITS;
+	viewpointx = mo->x + FixedMul(finecosine((angle>>ANGLETOFINESHIFT) & FINEMASK), dist);
+	viewpointy = mo->y + FixedMul(finesine((angle>>ANGLETOFINESHIFT) & FINEMASK), dist);
+
+	thiscam->angle = R_PointToAngle2(thiscam->x, thiscam->y, viewpointx, viewpointy);
+
+	// follow the player
+	thiscam->momx = FixedMul(x - thiscam->x, camspeed);
+	thiscam->momy = FixedMul(y - thiscam->y, camspeed);
+	thiscam->momz = FixedMul(z - thiscam->z, camspeed);
+}
+
+#endif

--- a/p_camera.h
+++ b/p_camera.h
@@ -1,0 +1,31 @@
+#ifndef __P_CAMERA_H__
+#define __P_CAMERA_H__
+
+#include "doomdef.h"
+#include "p_local.h"
+
+#ifdef USECAMERA
+typedef struct camera_s
+{
+	// Info for drawing: position.
+	fixed_t x, y, z;
+
+	angle_t angle; // orientation
+	angle_t aiming; // up/down (future)
+
+	struct subsector_s *subsector;
+	fixed_t floorz, ceilingz;
+
+	// Momentums used to update position
+	fixed_t momx, momy, momz;
+} camera_t;
+
+#define CAM_HEIGHT (16<<FRACBITS)
+#define CAM_RADIUS (20<<FRACBITS)
+#define CAM_DIST (128<<FRACBITS)
+
+extern camera_t camera, camera2;
+void P_MoveChaseCamera(player_t *player, camera_t *thiscam);
+#endif
+
+#endif

--- a/p_local.h
+++ b/p_local.h
@@ -99,6 +99,30 @@ void	P_RestoreResp(player_t* p);
 void	P_UpdateResp(player_t* p);
 void	R_ResetResp(player_t* p);
 
+#ifdef USECAMERA
+typedef struct camera_s
+{
+	// Info for drawing: position.
+	fixed_t x, y, z;
+
+	angle_t angle; // orientation
+	angle_t aiming; // up/down
+
+	struct subsector_s *subsector;
+	fixed_t floorz, ceilingz;
+
+	// Momentums used to update position
+	fixed_t momx, momy, momz;
+} camera_t;
+
+#define CAM_HEIGHT (16<<FRACBITS)
+#define CAM_RADIUS (20<<FRACBITS)
+#define CAM_DIST (128<<FRACBITS)
+
+extern camera_t camera, camera2;
+void P_CameraThinker(player_t *player, camera_t *thiscam);
+#endif
+
 /*
 ===============================================================================
 

--- a/p_local.h
+++ b/p_local.h
@@ -352,6 +352,11 @@ typedef struct
 
 void P_SlideMove (pslidemove_t *sm);
 
+#ifdef USECAMERA
+void P_CameraSlideMove (pslidemove_t *sm);
+boolean P_CameraTryMove (ptrymove_t *tm, mobj_t *thing, fixed_t x, fixed_t y);
+#endif
+
 #endif	/* __P_LOCAL__ */
 
 

--- a/p_local.h
+++ b/p_local.h
@@ -99,30 +99,6 @@ void	P_RestoreResp(player_t* p);
 void	P_UpdateResp(player_t* p);
 void	R_ResetResp(player_t* p);
 
-#ifdef USECAMERA
-typedef struct camera_s
-{
-	// Info for drawing: position.
-	fixed_t x, y, z;
-
-	angle_t angle; // orientation
-	angle_t aiming; // up/down
-
-	struct subsector_s *subsector;
-	fixed_t floorz, ceilingz;
-
-	// Momentums used to update position
-	fixed_t momx, momy, momz;
-} camera_t;
-
-#define CAM_HEIGHT (16<<FRACBITS)
-#define CAM_RADIUS (20<<FRACBITS)
-#define CAM_DIST (128<<FRACBITS)
-
-extern camera_t camera, camera2;
-void P_CameraThinker(player_t *player, camera_t *thiscam);
-#endif
-
 /*
 ===============================================================================
 
@@ -352,10 +328,45 @@ typedef struct
 
 void P_SlideMove (pslidemove_t *sm);
 
-#ifdef USECAMERA
-void P_CameraSlideMove (pslidemove_t *sm);
-boolean P_CameraTryMove (ptrymove_t *tm, mobj_t *thing, fixed_t x, fixed_t y);
-#endif
+typedef struct
+{
+	// input
+	mobj_t *tmthing;
+	fixed_t  tmx, tmy;
+
+	fixed_t  tmfloorz;   // current floor z for P_TryMove2
+	fixed_t  tmceilingz; // current ceiling z for P_TryMove2
+	line_t *blockline;  // possibly a special to activate
+
+	fixed_t tmbbox[4];
+	int     tmflags;
+	fixed_t tmdropoffz; // lowest point contacted
+
+	int    	numspechit;
+	line_t **spechit;
+
+	subsector_t *newsubsec; // destination subsector
+} pmovework_t;
+
+typedef struct
+{
+	mobj_t *slidething;
+	fixed_t slidex, slidey;     // the final position
+	fixed_t slidedx, slidedy;   // current move for completable frac
+	fixed_t blockfrac;          // the fraction of the move that gets completed
+	fixed_t blocknvx, blocknvy; // the vector of the line that blocks move
+	fixed_t endbox[4];          // final proposed position
+	fixed_t nvx, nvy;           // normalized line vector
+
+	vertex_t *p1, *p2; // p1, p2 are line endpoints
+	fixed_t p3x, p3y, p4x, p4y; // p3, p4 are move endpoints
+
+	int numspechit;
+	line_t **spechit;
+} pslidework_t;
+
+boolean PM_BoxCrossLine(line_t *ld, pmovework_t *mw) ATTR_DATA_CACHE_ALIGN;
+fixed_t P_CompletableFrac(pslidework_t *sw, fixed_t dx, fixed_t dy);
 
 #endif	/* __P_LOCAL__ */
 

--- a/p_map.c
+++ b/p_map.c
@@ -75,6 +75,16 @@ boolean P_TryMove (ptrymove_t *tm, mobj_t *thing, fixed_t x, fixed_t y)
 	return P_TryMove2 (tm, false);
 }
 
+#ifdef USECAMERA
+boolean P_CameraTryMove2(ptrymove_t *tm, boolean checkposonly);
+boolean P_CameraTryMove(ptrymove_t *tm, mobj_t *thing, fixed_t x, fixed_t y)
+{
+	tm->tmthing = thing;
+	tm->tmx = x;
+	tm->tmy = y;
+	return P_CameraTryMove2(tm, false);
+}
+#endif
 
 /* 
 ============================================================================== 

--- a/p_mobj.c
+++ b/p_mobj.c
@@ -428,6 +428,25 @@ y = 0xff500000;
 		for (i=0 ; i<NUMCARDS ; i++)
 			p->cards[i] = true;		/* give all cards in death match mode			 */
 
+#ifdef USECAMERA
+	camera_t *thiscam;
+	if (p == &players[consoleplayer])
+		thiscam = &camera;
+	else if (p == &players[consoleplayer ^ 1]) // splitscreen
+		thiscam = &camera2;
+
+	if (thiscam)
+	{
+		thiscam->x = mobj->x;
+		thiscam->y = mobj->y;
+		thiscam->z = mobj->z + mobj->height;
+		thiscam->angle = mobj->angle;
+		thiscam->subsector = mobj->subsector;
+		thiscam->floorz = thiscam->subsector->sector->floorheight;
+		thiscam->ceilingz = thiscam->subsector->sector->ceilingheight;
+	}
+#endif
+
 	if (!netgame)
 		return;
 

--- a/p_move.c
+++ b/p_move.c
@@ -29,29 +29,7 @@
 #include "doomdef.h"
 #include "p_local.h"
 
-// CALICO_TODO: these ought to be in headers.
-typedef struct
-{
-   // input
-   mobj_t  *tmthing;
-   fixed_t  tmx, tmy;
-
-   fixed_t  tmfloorz;   // current floor z for P_TryMove2
-   fixed_t  tmceilingz; // current ceiling z for P_TryMove2
-   line_t  *blockline;  // possibly a special to activate
-
-   fixed_t tmbbox[4];
-   int     tmflags;
-   fixed_t tmdropoffz; // lowest point contacted
-
-	int    	numspechit;
- 	line_t	**spechit;
-
-   subsector_t *newsubsec; // destination subsector
-} pmovework_t;
-
 boolean PIT_CheckThing(mobj_t* thing, pmovework_t *mw) ATTR_DATA_CACHE_ALIGN;
-static boolean PM_BoxCrossLine(line_t* ld, pmovework_t *mw) ATTR_DATA_CACHE_ALIGN;
 static boolean PIT_CheckLine(line_t* ld, pmovework_t *mw) ATTR_DATA_CACHE_ALIGN;
 static boolean PM_CrossCheck(line_t* ld, pmovework_t *mw) ATTR_DATA_CACHE_ALIGN;
 static boolean PM_CheckPosition(pmovework_t *mw) ATTR_DATA_CACHE_ALIGN;
@@ -138,7 +116,7 @@ boolean PIT_CheckThing(mobj_t *thing, pmovework_t *mw)
 //
 // Check if the thing intersects a linedef
 //
-static boolean PM_BoxCrossLine(line_t *ld, pmovework_t *mw)
+boolean PM_BoxCrossLine(line_t *ld, pmovework_t *mw)
 {
    fixed_t x1, x2, y1, y2;
    fixed_t lx, ly, ldx, ldy;
@@ -601,6 +579,34 @@ boolean P_CameraTryMove2(ptrymove_t *tm, boolean checkposonly)
     tmthing->floorz = mw.tmfloorz;
     tmthing->ceilingz = mw.tmceilingz;
     tmthing->x = mw.tmx;
+    tmthing->y = mw.tmy;
+
+    return true;
+}
+#endif
+
+void P_MoveCrossSpecials(mobj_t *tmthing, int numspechit, line_t **spechit, fixed_t oldx, fixed_t oldy)
+{
+    int i;
+
+    if ((tmthing->flags&(MF_TELEPORT|MF_NOCLIP)) )
+      return;
+
+    for (i = 0; i < numspechit; i++)
+    {
+      line_t *ld = spechit[i];
+      int side, oldside;
+      // see if the line was crossed
+      side = P_PointOnLineSide (tmthing->x, tmthing->y, ld);
+      oldside = P_PointOnLineSide (oldx, oldy, ld);
+      if (side != oldside)
+         P_CrossSpecialLine(ld, tmthing);
+    }
+}
+
+// EOF
+
+x;
     tmthing->y = mw.tmy;
 
     return true;

--- a/p_slide.c
+++ b/p_slide.c
@@ -514,5 +514,69 @@ void P_SlideMove(pslidemove_t *sm)
    sm->numspechit = sw.numspechit;
 }
 
+#ifdef USECAMERA
+//
+// Try to slide the player against walls by finding the closest move available.
+//
+void P_CameraSlideMove(pslidemove_t *sm)
+{
+    int i;
+    fixed_t dx, dy, rx, ry;
+    fixed_t frac, slide;
+    pslidework_t sw;
+    mobj_t *slidething = sm->slidething;
+
+    dx = slidething->momx;
+    dy = slidething->momy;
+    sw.slidex = slidething->x;
+    sw.slidey = slidething->y;
+    sw.slidething = slidething;
+    sw.numspechit = 0;
+    sw.spechit = &sm->spechit[0];
+
+    // perform a maximum of three bumps
+    for (i = 0; i < 3; i++)
+    {
+        frac = P_CompletableFrac(&sw, dx, dy);
+        if (frac != FRACUNIT)
+            frac -= 0x1000;
+        if (frac < 0)
+            frac = 0;
+
+        rx = FixedMul(frac, dx);
+        ry = FixedMul(frac, dy);
+
+        sw.slidex += rx;
+        sw.slidey += ry;
+
+        // made it the entire way
+        if (frac == FRACUNIT)
+        {
+            slidething->momx = dx;
+            slidething->momy = dy;
+            //         SL_CheckSpecialLines(&sw); // Camera doesn't trip lines
+            sm->slidex = sw.slidex;
+            sm->slidey = sw.slidey;
+            return;
+        }
+
+        // project the remaining move along the line that blocked movement
+        dx -= rx;
+        dy -= ry;
+        dx = FixedMul(dx, sw.blocknvx);
+        dy = FixedMul(dy, sw.blocknvy);
+        slide = dx + dy;
+
+        dx = FixedMul(slide, sw.blocknvx);
+        dy = FixedMul(slide, sw.blocknvy);
+    }
+
+    // some hideous situation has happened that won't let the camera slide
+    sm->slidex = slidething->x;
+    sm->slidey = slidething->y;
+    sm->slidething->momx = slidething->momy = 0;
+}
+#endif
+
 // EOF
 

--- a/p_slide.c
+++ b/p_slide.c
@@ -29,23 +29,6 @@
 #include "doomdef.h"
 #include "p_local.h"
 
-typedef struct
-{
-   mobj_t *slidething;
-   fixed_t slidex, slidey;     // the final position
-   fixed_t slidedx, slidedy;   // current move for completable frac
-   fixed_t blockfrac;          // the fraction of the move that gets completed
-   fixed_t blocknvx, blocknvy; // the vector of the line that blocks move
-   fixed_t endbox[4];          // final proposed position
-   fixed_t nvx, nvy;           // normalized line vector
-
-   vertex_t *p1, *p2; // p1, p2 are line endpoints
-   fixed_t p3x, p3y, p4x, p4y; // p3, p4 are move endpoints
-
-	int numspechit;
-	line_t **spechit;
-} pslidework_t;
-
 #define CLIPRADIUS 23
 
 enum
@@ -556,6 +539,31 @@ void P_CameraSlideMove(pslidemove_t *sm)
             slidething->momy = dy;
             //         SL_CheckSpecialLines(&sw); // Camera doesn't trip lines
             sm->slidex = sw.slidex;
+            sm->slidey = sw.slidey;
+            return;
+        }
+
+        // project the remaining move along the line that blocked movement
+        dx -= rx;
+        dy -= ry;
+        dx = FixedMul(dx, sw.blocknvx);
+        dy = FixedMul(dy, sw.blocknvy);
+        slide = dx + dy;
+
+        dx = FixedMul(slide, sw.blocknvx);
+        dy = FixedMul(slide, sw.blocknvy);
+    }
+
+    // some hideous situation has happened that won't let the camera slide
+    sm->slidex = slidething->x;
+    sm->slidey = slidething->y;
+    sm->slidething->momx = slidething->momy = 0;
+}
+#endif
+
+// EOF
+
+ex;
             sm->slidey = sw.slidey;
             return;
         }

--- a/r_main.c
+++ b/r_main.c
@@ -503,17 +503,41 @@ static void R_Setup (int displayplayer, visplane_t *visplanes_,
 
 	player = &players[displayplayer];
 
-	vd.viewplayer = player;
-	vd.viewx = player->mo->x;
-	vd.viewy = player->mo->y;
-	vd.viewz = player->viewz;
-	vd.viewangle = player->mo->angle;
+#ifdef USECAMERA
+	camera_t *thiscam = NULL;
 
-	vd.viewsin = finesine(vd.viewangle>>ANGLETOFINESHIFT);
-	vd.viewcos = finecosine(vd.viewangle>>ANGLETOFINESHIFT);
+	if (displayplayer == consoleplayer)
+		thiscam = &camera;
+	else if (displayplayer == (consoleplayer ^ 1)) // Splitscreen
+		thiscam = &camera2;
+
+#ifdef USECAMERAFORDEMOS
+	if (thiscam && demoplayback)
+#else
+	if (thiscam)
+#endif
+	{
+		vd.viewx = camera.x;
+		vd.viewy = camera.y;
+		vd.viewz = camera.z;
+		vd.viewangle = camera.angle;
+		vd.lightlevel = camera.subsector->sector->lightlevel; // SSNTails
+	}
+	else
+#endif
+	{
+		vd.viewx = player->mo->x;
+		vd.viewy = player->mo->y;
+		vd.viewz = player->viewz;
+		vd.viewangle = player->mo->angle;
+		vd.lightlevel = player->mo->subsector->sector->lightlevel;
+	}
+
+	vd.viewplayer = player;
+	vd.viewsin = finesine(vd.viewangle >> ANGLETOFINESHIFT);
+	vd.viewcos = finecosine(vd.viewangle >> ANGLETOFINESHIFT);
 
 	vd.displayplayer = displayplayer;
-	vd.lightlevel = player->mo->subsector->sector->lightlevel;
 	vd.fixedcolormap = 0;
 
 	vd.clipangle = xtoviewangle[0]<<FRACBITS;

--- a/r_main.c
+++ b/r_main.c
@@ -6,6 +6,7 @@
 #include "mars.h"
 #include "marshw.h"
 #endif
+#include "p_local.h"
 
 int16_t viewportWidth, viewportHeight;
 int16_t centerX, centerY;

--- a/r_main.c
+++ b/r_main.c
@@ -6,7 +6,7 @@
 #include "mars.h"
 #include "marshw.h"
 #endif
-#include "p_local.h"
+#include "p_camera.h"
 
 int16_t viewportWidth, viewportHeight;
 int16_t centerX, centerY;

--- a/r_phase3.c
+++ b/r_phase3.c
@@ -182,6 +182,15 @@ static void R_PrepPSprite(pspdef_t *psp)
    fixed_t      tx, x1, x2;
    const state_t* state;
 
+#ifdef USECAMERA
+#ifdef USECAMERAFORDEMOS
+   if (demoplayback)
+       return;
+#else
+   return; // No psprites in camera view
+#endif
+#endif
+
    state = &states[psp->state];
    sprdef = &sprites[state->sprite];
    sprframe = &spriteframes[sprdef->firstframe + (state->frame & FF_FRAMEMASK)];

--- a/r_phase8.c
+++ b/r_phase8.c
@@ -466,6 +466,15 @@ static void R_DrawPSprites(int sprscreenhalf)
     viswall_t *spr;
     unsigned vph = viewportHeight;
 
+#ifdef USECAMERA
+#ifdef USECAMERAFORDEMOS
+    if (demoplayback)
+        return;
+#else
+    return; // No psprites in camera view
+#endif
+#endif
+
     I_SetThreadLocalVar(DOOMTLS_COLORMAP, dc_colormaps);
 
     // draw psprites


### PR DESCRIPTION
This pull request adds a chasecam during demo playback. It can be disabled/enabled with the USECAMERA preprocessor macro.
It's also possible to enable it during regular play by removing the USECAMERAFORDEMOS preprocessor macro.


https://github.com/viciious/d32xr/assets/159929665/56703cd3-b1b0-4c59-b4cb-ad1684a14051

