### PR TITLE
For demos that don't end in death, don't read past demo data.

### DIFF
--- a/d_main.c
+++ b/d_main.c
@@ -418,7 +418,10 @@ int MiniLoop ( void (*start)(void),  void (*stop)(void)
 			*demo_p++ = buttons;
 		
 		if ((demorecording || demoplayback) && (buttons & BT_PAUSE) )
-			exit = ga_completed;
+		{
+			exit = ga_exitdemo; // Demo finished by choice, not by death
+			break;
+		}
 
 		if (gameaction == ga_warped || gameaction == ga_startnew)
 		{
@@ -830,8 +833,6 @@ int  RunDemo (char *demoname)
 void RunMenu (void)
 {
 #ifdef MARS
-	int exit = ga_exitdemo;
-
 	M_Start();
 	if (!gameinfo.noAttractDemo) {
 		do {
@@ -847,11 +848,9 @@ void RunMenu (void)
 				if (lump == -1)
 					break;
 
-				exit = RunDemo(demo);
-				if (exit == ga_exitdemo)
-					break;
+				RunDemo(demo);
 			}
-		} while (exit != ga_exitdemo);
+		} while (true);
 	}
 	M_Stop();
 #else


### PR DESCRIPTION
Demos that don't end in death will continue to read the demo_p pointer, reading past the demo lump data to humorous and undesirable effect.

https://github.com/viciious/d32xr/assets/159929665/cd8497f1-28e7-4b9b-a514-dad47b49dfef


The use of ga_exitdemo here appears to be not utilized correctly, and the use of BT_PAUSE to end a demo was not being handled the right way. This has been corrected so the attract mode will continue to function as expected.