### PR TITLE
Account for leftoffset when flipping sprites

### DIFF
--- a/r_phase3.c
+++ b/r_phase3.c
@@ -91,7 +91,11 @@ static void R_PrepMobj(mobj_t *thing)
    gzt = thing->z - vd.viewz;
 
    // calculate edges of the shape
-   tx -= ((fixed_t)BIGSHORT(patch->leftoffset)) << FRACBITS;
+   if (flip)
+      tx -= ((fixed_t)BIGSHORT(patch->width)-(fixed_t)BIGSHORT(patch->leftoffset)) << FRACBITS;
+   else
+      tx -= ((fixed_t)BIGSHORT(patch->leftoffset)) << FRACBITS;
+
    x1 = FixedMul(tx, xscale);
    x1 = (centerXFrac + x1) / FRACUNIT;
 
@@ -130,16 +134,22 @@ static void R_PrepMobj(mobj_t *thing)
 #endif
    vis->x1       = x1 < 0 ? 0 : x1;
    vis->x2       = x2 >= viewportWidth ? viewportWidth - 1 : x2;
-   vis->gx       = thing->x / FRACUNIT;
-   vis->gy       = thing->y / FRACUNIT;
+   vis->gx       = thing->x >> FRACBITS;
+   vis->gy       = thing->y >> FRACBITS;
    vis->xscale   = xscale;
-   vis->xiscale  = FixedDiv(FRACUNIT, xscale);
    vis->yscale   = FixedMul(xscale, stretch);
    vis->texturemid = texmid;
-   vis->startfrac = 0;
 
    if(flip)
-      vis->xiscale = -vis->xiscale;
+   {
+      vis->xiscale = -FixedDiv(FRACUNIT, xscale);
+      vis->startfrac = ((fixed_t)BIGSHORT(patch->width) << FRACBITS) - 1;
+   }
+   else
+   {
+      vis->xiscale = FixedDiv(FRACUNIT, xscale);
+      vis->startfrac = 0;
+   }
 
    if (vis->xiscale < 0)
        vis->startfrac = ((fixed_t)BIGSHORT(patch->width) << FRACBITS) - 1;


### PR DESCRIPTION
This is most easily observed in splitscreen or network play, but it's also possible to witness this with monsters and other multi-directional sprites, albeit more difficult under high action scenarios - but sprites were not being properly flipped if the center of the image was not on the X axis.

This pull request fixes that issue, as well as speeds up (hopefully) a few calculations when preparing a sprite for rendering.

Broken (original behavior):

https://github.com/viciious/d32xr/assets/159929665/d53496e4-27ea-4bab-9140-4042c0934a4f

Fixed:

https://github.com/viciious/d32xr/assets/159929665/6a4b6653-e3b7-482e-b9ac-7d9d721fe487

